### PR TITLE
Extend webhook functionality

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,9 @@
 language: php
 
 php:
-  - 5.6
-  - 7.0
-  - 7.1
   - 7.2
+  - 7.3
+  - 7.4
 
 env:
   global:
@@ -12,7 +11,7 @@ env:
 
 matrix:
   include:
-    - php: 5.6
+    - php: 7.2
       env: setup=lowest
 
 sudo: false

--- a/composer.json
+++ b/composer.json
@@ -27,12 +27,13 @@
         "psr-4": { "Omnipay\\PayPal\\" : "src/" }
     },
     "require": {
-        "omnipay/common": "^3"
+        "php": "^7.2",
+        "omnipay/common": "^3.0"
     },
     "require-dev": {
-        "omnipay/tests": "^3",
-        "squizlabs/php_codesniffer": "^3",
-        "phpro/grumphp": "^0.14"
+        "omnipay/tests": "^3.1",
+        "squizlabs/php_codesniffer": "^3.5",
+        "phpro/grumphp": "^0.19"
     },
     "extra": {
         "branch-alias": {

--- a/grumphp.yml
+++ b/grumphp.yml
@@ -1,6 +1,4 @@
-parameters:
-    git_dir: .
-    bin_dir: vendor/bin
+grumphp:
     tasks:
         phpunit:
             config_file: ~

--- a/src/Message/RestCreateWebhookRequest.php
+++ b/src/Message/RestCreateWebhookRequest.php
@@ -2,16 +2,22 @@
 
 namespace Omnipay\PayPal\Message;
 
+use Omnipay\Common\Exception\InvalidRequestException;
+
 final class RestCreateWebhookRequest extends AbstractRestRequest
 {
     /**
      * @inheritDoc
+     *
+     * @throws InvalidRequestException
      */
-    public function getData()
+    public function getData(): array
     {
+        $this->validate('event_types', 'webhook_url');
+
         return [
             'event_types' => \array_map(
-                function ($value) {
+                static function (string $value): array {
                     return ['name' => $value];
                 },
                 $this->getEventTypes()
@@ -20,47 +26,39 @@ final class RestCreateWebhookRequest extends AbstractRestRequest
         ];
     }
 
+    public function getEndpoint(): string
+    {
+        return parent::getEndpoint() . '/notifications/webhooks';
+    }
+
     /**
-     * @return array
+     * @return list<string>
      */
-    public function getEventTypes()
+    public function getEventTypes(): array
     {
         return $this->getParameter('event_types') ?: [];
     }
 
-    /**
-     * @inheritDoc
-     */
-    public function getEndpoint()
-    {
-        return parent::getEndpoint().'/notifications/webhooks';
-    }
-
-    /**
-     * @return string|null
-     */
-    public function getUrl()
+    public function getUrl(): ?string
     {
         return $this->getParameter('webhook_url');
     }
 
     /**
-     * @param array $eventTypes
-     *
-     * @return $this
+     * @param list<string> $eventTypes
      */
-    public function setEventTypes(array $eventTypes)
+    public function setEventTypes(array $eventTypes): self
     {
         return $this->setParameter('event_types', $eventTypes);
     }
 
-    /**
-     * @param string $url
-     *
-     * @return $this
-     */
-    public function setUrl($url)
+    public function setUrl(string $url): self
     {
         return $this->setParameter('webhook_url', $url);
+    }
+
+    protected function createResponse($data, $statusCode): RestCreateWebhookResponse
+    {
+        return $this->response = new RestCreateWebhookResponse($this, $data, $statusCode);
     }
 }

--- a/src/Message/RestCreateWebhookResponse.php
+++ b/src/Message/RestCreateWebhookResponse.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace Omnipay\PayPal\Message;
+
+use Omnipay\PayPal\Support\Webhook;
+
+final class RestCreateWebhookResponse extends RestResponse
+{
+    public function getWebhook(): ?Webhook
+    {
+        if (!$this->isSuccessful()) {
+            return null;
+        }
+
+        return new Webhook(
+            $this->data['id'],
+            $this->data['url'],
+            \array_map(
+                static function (array $eventType): string {
+                    return $eventType['name'];
+                },
+                $this->data['event_types']
+            )
+        );
+    }
+}

--- a/src/Message/RestDeleteWebhookRequest.php
+++ b/src/Message/RestDeleteWebhookRequest.php
@@ -1,0 +1,45 @@
+<?php
+
+namespace Omnipay\PayPal\Message;
+
+use Omnipay\Common\Exception\InvalidRequestException;
+
+/**
+ * PayPal REST Delete Webhook request
+ *
+ * @link https://developer.paypal.com/docs/api/webhooks/v1/#webhooks_delete
+ */
+final class RestDeleteWebhookRequest extends AbstractRestRequest
+{
+    /**
+     * @inheritDoc
+     *
+     * @throws InvalidRequestException
+     */
+    public function getData(): array
+    {
+        $this->validate('webhook_id');
+
+        return [];
+    }
+
+    public function getEndpoint(): string
+    {
+        return parent::getEndpoint() . '/notifications/webhooks/' . $this->getWebhookId();
+    }
+
+    protected function getHttpMethod(): string
+    {
+        return 'DELETE';
+    }
+
+    public function getWebhookId(): string
+    {
+        return $this->getParameter('webhook_id');
+    }
+
+    public function setWebhookId(string $webhookId): self
+    {
+        return $this->setParameter('webhook_id', $webhookId);
+    }
+}

--- a/src/Message/RestListWebhooksRequest.php
+++ b/src/Message/RestListWebhooksRequest.php
@@ -5,32 +5,26 @@ namespace Omnipay\PayPal\Message;
 /**
  * PayPal REST List Webhooks request
  *
- * @link https://developer.paypal.com/docs/api/webhooks/#webhooks_get-all
+ * @link https://developer.paypal.com/docs/api/webhooks/v1/#webhooks_list
  */
 final class RestListWebhooksRequest extends AbstractRestRequest
 {
-    /**
-     * @inheritDoc
-     */
-    public function getData()
+    public function getData(): array
     {
         return [];
     }
 
-    /**
-     * @inheritDoc
-     */
-    public function getEndpoint()
+    public function getEndpoint(): string
     {
-        return parent::getEndpoint().'/notifications/webhooks';
+        return parent::getEndpoint() . '/notifications/webhooks';
     }
 
-    /**
-     * Get HTTP Method.
-     *
-     * @return string
-     */
-    protected function getHttpMethod()
+    protected function createResponse($data, $statusCode): RestListWebhooksResponse
+    {
+        return $this->response = new RestListWebhooksResponse($this, $data, $statusCode);
+    }
+
+    protected function getHttpMethod(): string
     {
         return 'GET';
     }

--- a/src/Message/RestListWebhooksResponse.php
+++ b/src/Message/RestListWebhooksResponse.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace Omnipay\PayPal\Message;
+
+use Omnipay\Common\Message\AbstractResponse;
+use Omnipay\Common\Message\RequestInterface;
+use Omnipay\PayPal\Support\Webhook;
+
+final class RestListWebhooksResponse extends RestResponse
+{
+    /**
+     * @return list<Webhook>
+     */
+    public function getWebhooks(): array
+    {
+        if (!isset($this->data['webhooks'])) {
+            return [];
+        }
+
+        return \array_map(
+            static function (array $webhook): Webhook {
+                return new Webhook(
+                    $webhook['id'],
+                    $webhook['url'],
+                    \array_map(
+                        static function (array $eventType): string {
+                            return $eventType['name'];
+                        },
+                        $webhook['event_types']
+                    )
+                );
+            },
+            $this->data['webhooks']
+        );
+    }
+}

--- a/src/Message/RestUpdateWebhookRequest.php
+++ b/src/Message/RestUpdateWebhookRequest.php
@@ -1,0 +1,95 @@
+<?php
+
+namespace Omnipay\PayPal\Message;
+
+use Omnipay\Common\Exception\InvalidRequestException;
+
+/**
+ * PayPal REST Update Webhook request
+ *
+ * @link https://developer.paypal.com/docs/api/webhooks/v1/#webhooks_delete
+ */
+final class RestUpdateWebhookRequest extends AbstractRestRequest
+{
+    /**
+     * @inheritDoc
+     *
+     * @throws InvalidRequestException
+     */
+    public function getData(): array
+    {
+        $this->validate('webhook_id');
+
+        $data = [];
+
+        if (null !== $url = $this->getUrl()) {
+            $data[] = [
+                'op' => 'replace',
+                'path' => '/url',
+                'value' => $url,
+            ];
+        }
+
+        $eventTypes = $this->getEventTypes();
+        if (!empty($eventTypes)) {
+            $data[] = [
+                'op' => 'replace',
+                'path' => '/event_types',
+                'value' => \array_map(
+                    static function (string $eventType): array {
+                        return ['name' => $eventType];
+                    },
+                    $eventTypes
+                ),
+            ];
+        }
+
+        return $data;
+    }
+
+    public function getEndpoint(): string
+    {
+        return parent::getEndpoint() . '/notifications/webhooks/' . $this->getWebhookId();
+    }
+
+    protected function getHttpMethod(): string
+    {
+        return 'PATCH';
+    }
+
+    /**
+     * @return list<string>
+     */
+    public function getEventTypes(): array
+    {
+        return $this->getParameter('event_types') ?: [];
+    }
+
+    public function getUrl(): ?string
+    {
+        return $this->getParameter('webhook_url');
+    }
+
+    public function getWebhookId(): string
+    {
+        return $this->getParameter('webhook_id');
+    }
+
+    /**
+     * @param list<string> $eventTypes
+     */
+    public function setEventTypes(array $eventTypes): self
+    {
+        return $this->setParameter('event_types', $eventTypes);
+    }
+
+    public function setUrl(string $url): self
+    {
+        return $this->setParameter('webhook_url', $url);
+    }
+
+    public function setWebhookId(string $webhookId): self
+    {
+        return $this->setParameter('webhook_id', $webhookId);
+    }
+}

--- a/src/RestGateway.php
+++ b/src/RestGateway.php
@@ -10,7 +10,9 @@ use Omnipay\PayPal\Message\ProAuthorizeRequest;
 use Omnipay\PayPal\Message\CaptureRequest;
 use Omnipay\PayPal\Message\RefundRequest;
 use Omnipay\PayPal\Message\RestCreateWebhookRequest;
+use Omnipay\PayPal\Message\RestDeleteWebhookRequest;
 use Omnipay\PayPal\Message\RestListWebhooksRequest;
+use Omnipay\PayPal\Message\RestUpdateWebhookRequest;
 use Omnipay\PayPal\Message\RestVerifyWebhookSignatureRequest;
 
 /**
@@ -341,6 +343,10 @@ class RestGateway extends AbstractGateway
      * @param string $class
      * @param array $parameters
      * @return \Omnipay\PayPal\Message\AbstractRestRequest
+     *
+     * @psalm-template T of \Omnipay\PayPal\Message\AbstractRestRequest
+     * @psalm-param class-string<T> $class
+     * @psalm-return T
      */
     public function createRequest($class, array $parameters = array())
     {
@@ -432,16 +438,6 @@ class RestGateway extends AbstractGateway
     public function completePurchase(array $parameters = array())
     {
         return $this->createRequest('\Omnipay\PayPal\Message\RestCompletePurchaseRequest', $parameters);
-    }
-
-    /**
-     * @param array $parameters
-     *
-     * @return RestCreateWebhookRequest
-     */
-    public function createWebhook(array $parameters = [])
-    {
-        return $this->createRequest(RestCreateWebhookRequest::class, $parameters);
     }
 
     // TODO: Update a payment resource https://developer.paypal.com/docs/api/#update-a-payment-resource
@@ -752,21 +748,41 @@ class RestGateway extends AbstractGateway
     }
 
     /**
-     * @param array $parameters
-     *
-     * @return RestListWebhooksRequest
+     * @param mixed[] $parameters
      */
-    public function listWebhooks(array $parameters = [])
+    public function createWebhook(array $parameters = []): RestCreateWebhookRequest
+    {
+        return $this->createRequest(RestCreateWebhookRequest::class, $parameters);
+    }
+
+    /**
+     * @param mixed[] $parameters
+     */
+    public function deleteWebhook(array $parameters = []): RestDeleteWebhookRequest
+    {
+        return $this->createRequest(RestDeleteWebhookRequest::class, $parameters);
+    }
+
+    /**
+     * @param mixed[] $parameters
+     */
+    public function listWebhooks(array $parameters = []): RestListWebhooksRequest
     {
         return $this->createRequest(RestListWebhooksRequest::class, $parameters);
     }
 
     /**
-     * @param array $parameters
-     *
-     * @return RestVerifyWebhookSignatureRequest
+     * @param mixed[] $parameters
      */
-    public function verifyWebhookSignature(array $parameters = [])
+    public function updateWebhook(array $parameters = []): RestUpdateWebhookRequest
+    {
+        return $this->createRequest(RestUpdateWebhookRequest::class, $parameters);
+    }
+
+    /**
+     * @param mixed[] $parameters
+     */
+    public function verifyWebhookSignature(array $parameters = []): RestVerifyWebhookSignatureRequest
     {
         return $this->createRequest(RestVerifyWebhookSignatureRequest::class, $parameters);
     }

--- a/src/Support/Webhook.php
+++ b/src/Support/Webhook.php
@@ -1,0 +1,50 @@
+<?php
+declare(strict_types=1);
+
+namespace Omnipay\PayPal\Support;
+
+final class Webhook
+{
+    /**
+     * @var string
+     */
+    private $id;
+
+    /**
+     * @var string
+     */
+    private $url;
+
+    /**
+     * @var list<string>
+     */
+    private $eventTypes;
+
+    /**
+     * @param list<string> $eventTypes
+     */
+    public function __construct(string $id, string $url, array $eventTypes)
+    {
+        $this->id = $id;
+        $this->url = $url;
+        $this->eventTypes = $eventTypes;
+    }
+
+    public function getId(): string
+    {
+        return $this->id;
+    }
+
+    public function getUrl(): string
+    {
+        return $this->url;
+    }
+
+    /**
+     * @return list<string>
+     */
+    public function getEventTypes(): array
+    {
+        return $this->eventTypes;
+    }
+}

--- a/tests/Message/RestCreateWebhookRequestTest.php
+++ b/tests/Message/RestCreateWebhookRequestTest.php
@@ -11,14 +11,14 @@ final class RestCreateWebhookRequestTest extends TestCase
      */
     private $request;
 
-    public function setUp()
+    public function setUp(): void
     {
         $client = $this->getHttpClient();
         $request = $this->getHttpRequest();
         $this->request = new RestCreateWebhookRequest($client, $request);
     }
 
-    public function testGetData()
+    public function testGetData(): void
     {
         $event1 = 'PAYMENT.AUTHORIZATION.CREATED';
         $event2 = 'PAYMENT.AUTHORIZATION.VOIDED';
@@ -30,7 +30,7 @@ final class RestCreateWebhookRequestTest extends TestCase
             ]
         );
 
-        $this->assertEquals(
+        self::assertEquals(
             [
                 'event_types' => [['name' => $event1], ['name' => $event2]],
                 'url' => $url,
@@ -39,19 +39,19 @@ final class RestCreateWebhookRequestTest extends TestCase
         );
     }
 
-    public function testGetEndpoint()
+    public function testGetEndpoint(): void
     {
-        $this->assertStringEndsWith('/notifications/webhooks', $this->request->getEndpoint());
+        self::assertStringEndsWith('/notifications/webhooks', $this->request->getEndpoint());
     }
 
-    public function testGetEventTypes()
+    public function testGetEventTypes(): void
     {
         $value = ['PAYMENT.AUTHORIZATION.CREATED'];
         $this->request->setEventTypes($value);
         self::assertSame($value, $this->request->getEventTypes());
     }
 
-    public function testGetUrl()
+    public function testGetUrl(): void
     {
         $value = 'https://foo.bar/baz';
         $this->request->setUrl($value);

--- a/tests/Message/RestCreateWebhookResponseTest.php
+++ b/tests/Message/RestCreateWebhookResponseTest.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace Omnipay\PayPal\Message;
+
+use Omnipay\Tests\TestCase;
+
+final class RestCreateWebhookResponseTest extends TestCase
+{
+    public function testResponse(): void
+    {
+        $httpResponse = $this->getMockHttpResponse('RestCreateWebhookSuccess.txt');
+
+        $response = new RestCreateWebhookResponse(
+            $this->getMockRequest(),
+            \json_decode($httpResponse->getBody()->getContents(), true),
+            $httpResponse->getStatusCode()
+        );
+
+        self::assertTrue($response->isSuccessful());
+
+        $webhook = $response->getWebhook();
+
+        self::assertNotNull($webhook);
+        self::assertSame('0EH40505U7160970P', $webhook->getId());
+        self::assertSame('https://example.com/example_webhook', $webhook->getUrl());
+        self::assertSame(
+            [
+                'PAYMENT.AUTHORIZATION.CREATED',
+                'PAYMENT.AUTHORIZATION.VOIDED',
+            ],
+            $webhook->getEventTypes()
+        );
+    }
+}

--- a/tests/Message/RestDeleteWebhookRequestTest.php
+++ b/tests/Message/RestDeleteWebhookRequestTest.php
@@ -1,0 +1,43 @@
+<?php
+declare(strict_types=1);
+
+namespace Omnipay\PayPal\Message;
+
+use Omnipay\PayPal\Message\RestDeleteWebhookRequest;
+use Omnipay\Tests\TestCase;
+
+final class RestDeleteWebhookRequestTest extends TestCase
+{
+    /**
+     * @var RestDeleteWebhookRequest
+     */
+    private $request;
+
+    public function setUp(): void
+    {
+        $client = $this->getHttpClient();
+        $request = $this->getHttpRequest();
+        $this->request = new RestDeleteWebhookRequest($client, $request);
+    }
+
+    public function testGetFullData(): void
+    {
+        $this->request->initialize(['webhook_id' => 'f0oB4r']);
+
+        self::assertEquals([], $this->request->getData());
+    }
+
+    public function testGetEndpoint(): void
+    {
+        $this->request->initialize(['webhook_id' => 'f0oB4r']);
+
+        self::assertStringEndsWith('/notifications/webhooks/f0oB4r', $this->request->getEndpoint());
+    }
+
+    public function testWebhookIdAccessors(): void
+    {
+        $this->request->setWebhookId('f0oB4r');
+
+        self::assertSame('f0oB4r', $this->request->getWebhookId());
+    }
+}

--- a/tests/Message/RestListWebhooksRequestTest.php
+++ b/tests/Message/RestListWebhooksRequestTest.php
@@ -11,20 +11,20 @@ final class RestListWebhooksRequestTest extends TestCase
      */
     private $request;
 
-    public function setUp()
+    public function setUp(): void
     {
         $client = $this->getHttpClient();
         $request = $this->getHttpRequest();
         $this->request = new RestListWebhooksRequest($client, $request);
     }
 
-    public function testEndpoint()
+    public function testEndpoint(): void
     {
-        $this->assertStringEndsWith('/notifications/webhooks', $this->request->getEndpoint());
+        self::assertStringEndsWith('/notifications/webhooks', $this->request->getEndpoint());
     }
 
-    public function testGetData()
+    public function testGetData(): void
     {
-        $this->assertEmpty($this->request->getData());
+        self::assertSame([], $this->request->getData());
     }
 }

--- a/tests/Message/RestListWebhooksResponseTest.php
+++ b/tests/Message/RestListWebhooksResponseTest.php
@@ -1,0 +1,43 @@
+<?php
+
+namespace Omnipay\PayPal\Message;
+
+use Omnipay\Tests\TestCase;
+
+final class RestListWebhooksResponseTest extends TestCase
+{
+    public function testResponse(): void
+    {
+        $httpResponse = $this->getMockHttpResponse('RestListWebhooksSuccess.txt');
+
+        $response = new RestListWebhooksResponse(
+            $this->getMockRequest(),
+            \json_decode($httpResponse->getBody()->getContents(), true),
+            $httpResponse->getStatusCode()
+        );
+
+        self::assertTrue($response->isSuccessful());
+
+        $webhooks = $response->getWebhooks();
+        self::assertCount(2, $webhooks);
+
+        self::assertSame('40Y916089Y8324740', $webhooks[0]->getId());
+        self::assertSame('https://example.com/example_webhook', $webhooks[0]->getUrl());
+        self::assertSame(
+            [
+                'PAYMENT.AUTHORIZATION.CREATED',
+                'PAYMENT.AUTHORIZATION.VOIDED',
+            ],
+            $webhooks[0]->getEventTypes()
+        );
+
+        self::assertSame('0EH40505U7160970P', $webhooks[1]->getId());
+        self::assertSame('https://example.com/another_example_webhook', $webhooks[1]->getUrl());
+        self::assertSame(
+            [
+                'PAYMENT.SALE.REFUNDED',
+            ],
+            $webhooks[1]->getEventTypes()
+        );
+    }
+}

--- a/tests/Message/RestUpdateWebhookRequestTest.php
+++ b/tests/Message/RestUpdateWebhookRequestTest.php
@@ -1,0 +1,124 @@
+<?php
+declare(strict_types=1);
+
+namespace Omnipay\PayPal\Message;
+
+use Omnipay\Tests\TestCase;
+
+final class RestUpdateWebhookRequestTest extends TestCase
+{
+    /**
+     * @var RestUpdateWebhookRequest
+     */
+    private $request;
+
+    public function setUp(): void
+    {
+        $client = $this->getHttpClient();
+        $request = $this->getHttpRequest();
+        $this->request = new RestUpdateWebhookRequest($client, $request);
+    }
+
+    public function testGetFullData(): void
+    {
+        $this->request->initialize(
+            [
+                'event_types' => ['foo', 'bar'],
+                'url' => 'https://foo.bar/',
+                'webhook_id' => 'f0oB4r',
+            ]
+        );
+
+        self::assertEquals(
+            [
+                [
+                    'op' => 'replace',
+                    'path' => '/url',
+                    'value' => 'https://foo.bar/',
+                ],
+                [
+                    'op' => 'replace',
+                    'path' => '/event_types',
+                    'value' => [
+                        ['name' => 'foo'],
+                        ['name' => 'bar'],
+                    ],
+                ],
+            ],
+            $this->request->getData()
+        );
+    }
+
+    public function testGetUrlData(): void
+    {
+        $this->request->initialize(
+            [
+                'url' => 'https://foo.bar/',
+                'webhook_id' => 'f0oB4r',
+            ]
+        );
+
+        self::assertEquals(
+            [
+                [
+                    'op' => 'replace',
+                    'path' => '/url',
+                    'value' => 'https://foo.bar/',
+                ],
+            ],
+            $this->request->getData()
+        );
+    }
+
+    public function testGetEventTypesData(): void
+    {
+        $this->request->initialize(
+            [
+                'event_types' => ['foo', 'bar'],
+                'webhook_id' => 'f0oB4r',
+            ]
+        );
+
+        self::assertEquals(
+            [
+                [
+                    'op' => 'replace',
+                    'path' => '/event_types',
+                    'value' => [
+                        ['name' => 'foo'],
+                        ['name' => 'bar'],
+                    ],
+                ],
+            ],
+            $this->request->getData()
+        );
+    }
+
+    public function testGetEndpoint(): void
+    {
+        $this->request->initialize(['webhook_id' => 'f0oB4r']);
+
+        self::assertStringEndsWith('/notifications/webhooks/f0oB4r', $this->request->getEndpoint());
+    }
+
+    public function testEventTypesAccessors(): void
+    {
+        $this->request->setEventTypes(['foo', 'bar']);
+
+        self::assertSame(['foo', 'bar'], $this->request->getEventTypes());
+    }
+
+    public function testUrlAccessors(): void
+    {
+        $this->request->setUrl('https://foo.bar/');
+
+        self::assertSame('https://foo.bar/', $this->request->getUrl());
+    }
+
+    public function testWebhookIdAccessors(): void
+    {
+        $this->request->setWebhookId('f0oB4r');
+
+        self::assertSame('f0oB4r', $this->request->getWebhookId());
+    }
+}

--- a/tests/Mock/RestCreateWebhookSuccess.txt
+++ b/tests/Mock/RestCreateWebhookSuccess.txt
@@ -1,0 +1,42 @@
+HTTP/1.1 201 Created
+Server: Apache-Coyote/1.1
+PROXY_SERVER_INFO: host=slcsbjava2.slc.paypal.com;threadId=76018
+Paypal-Debug-Id: 965491cb1a1e5
+SERVER_INFO: paymentsplatformserv:v1.payments.sale&CalThreadId=129&TopLevelTxnStartTime=14701c36ef9&Host=slcsbjm3.slc.paypal.com&pid=15797
+CORRELATION-ID: 965491cb1a1e5
+Content-Language: *
+Date: Fri, 04 Jul 2014 14:24:52 GMT
+Content-Type: application/json
+Content-Length: 592
+
+{
+  "id": "0EH40505U7160970P",
+  "url": "https://example.com/example_webhook",
+  "event_types": [
+    {
+      "name": "PAYMENT.AUTHORIZATION.CREATED",
+      "description": "A payment authorization was created."
+    },
+    {
+      "name": "PAYMENT.AUTHORIZATION.VOIDED",
+      "description": "A payment authorization was voided."
+    }
+  ],
+  "links": [
+    {
+      "href": "https://api.paypal.com/v1/notifications/webhooks/0EH40505U7160970P",
+      "rel": "self",
+      "method": "GET"
+    },
+    {
+      "href": "https://api.paypal.com/v1/notifications/webhooks/0EH40505U7160970P",
+      "rel": "update",
+      "method": "PATCH"
+    },
+    {
+      "href": "https://api.paypal.com/v1/notifications/webhooks/0EH40505U7160970P",
+      "rel": "delete",
+      "method": "DELETE"
+    }
+  ]
+}

--- a/tests/Mock/RestListWebhooksSuccess.txt
+++ b/tests/Mock/RestListWebhooksSuccess.txt
@@ -1,0 +1,73 @@
+HTTP/1.1 200 OK
+Server: Apache-Coyote/1.1
+PROXY_SERVER_INFO: host=slcsbjava2.slc.paypal.com;threadId=76018
+Paypal-Debug-Id: 965491cb1a1e5
+SERVER_INFO: paymentsplatformserv:v1.payments.sale&CalThreadId=129&TopLevelTxnStartTime=14701c36ef9&Host=slcsbjm3.slc.paypal.com&pid=15797
+CORRELATION-ID: 965491cb1a1e5
+Content-Language: *
+Date: Fri, 04 Jul 2014 14:24:52 GMT
+Content-Type: application/json
+Content-Length: 592
+
+{
+  "webhooks": [
+    {
+      "id": "40Y916089Y8324740",
+      "url": "https://example.com/example_webhook",
+      "event_types": [
+        {
+          "name": "PAYMENT.AUTHORIZATION.CREATED",
+          "description": "A payment authorization was created."
+        },
+        {
+          "name": "PAYMENT.AUTHORIZATION.VOIDED",
+          "description": "A payment authorization was voided."
+        }
+      ],
+      "links": [
+        {
+          "href": "https://api.paypal.com/v1/notifications/webhooks/40Y916089Y8324740",
+          "rel": "self",
+          "method": "GET"
+        },
+        {
+          "href": "https://api.paypal.com/v1/notifications/webhooks/40Y916089Y8324740",
+          "rel": "update",
+          "method": "PATCH"
+        },
+        {
+          "href": "https://api.paypal.com/v1/notifications/webhooks/40Y916089Y8324740",
+          "rel": "delete",
+          "method": "DELETE"
+        }
+      ]
+    },
+    {
+      "id": "0EH40505U7160970P",
+      "url": "https://example.com/another_example_webhook",
+      "event_types": [
+        {
+          "name": "PAYMENT.SALE.REFUNDED",
+          "description": "A payment sale was refunded."
+        }
+      ],
+      "links": [
+        {
+          "href": "https://api.paypal.com/v1/notifications/webhooks/0EH40505U7160970P",
+          "rel": "self",
+          "method": "GET"
+        },
+        {
+          "href": "https://api.paypal.com/v1/notifications/webhooks/0EH40505U7160970P",
+          "rel": "update",
+          "method": "PATCH"
+        },
+        {
+          "href": "https://api.paypal.com/v1/notifications/webhooks/0EH40505U7160970P",
+          "rel": "delete",
+          "method": "DELETE"
+        }
+      ]
+    }
+  ]
+}

--- a/tests/RestGatewayTest.php
+++ b/tests/RestGatewayTest.php
@@ -232,13 +232,24 @@ class RestGatewayTest extends GatewayTestCase
         $this->assertNull($response->getMessage());
     }
 
-    public function testCreateWebhook()
+    public function testCreateWebhook(): void
     {
-        $request = $this->gateway->createWebhook([]);
+        $request = $this->gateway->createWebhook(
+            [
+                'event_types' => ['PAYMENT.SALE.REFUNDED'],
+                'url' => 'https://foo.bar/'
+            ]
+        );
 
-        $this->assertInstanceOf(RestCreateWebhookRequest::class, $request);
-        $this->assertSame('https://api.paypal.com/v1/notifications/webhooks', $request->getEndpoint());
-        $this->assertEquals(['event_types' => [], 'url' => null], $request->getData());
+        self::assertInstanceOf(RestCreateWebhookRequest::class, $request);
+        self::assertSame('https://api.paypal.com/v1/notifications/webhooks', $request->getEndpoint());
+        self::assertEquals(
+            [
+                'event_types' => [['name' => 'PAYMENT.SALE.REFUNDED']],
+                'url' => 'https://foo.bar/'
+            ],
+            $request->getData()
+        );
     }
 
     public function testPayWithSavedCard()

--- a/tests/Support/WebhookTest.php
+++ b/tests/Support/WebhookTest.php
@@ -1,0 +1,19 @@
+<?php
+declare(strict_types=1);
+
+namespace Omnipay\PayPal\Support;
+
+use Omnipay\PayPal\Support\Webhook;
+use PHPUnit\Framework\TestCase;
+
+final class WebhookTest extends TestCase
+{
+    public function testAccessors(): void
+    {
+        $webhook = new Webhook('f0oB4r', 'https://foo.bar/', ['foo', 'bar']);
+
+        self::assertSame('f0oB4r', $webhook->getId());
+        self::assertSame('https://foo.bar/', $webhook->getUrl());
+        self::assertSame(['foo', 'bar'], $webhook->getEventTypes());
+    }
+}


### PR DESCRIPTION
Adds:
- Update Webhook
- Delete Webhook

Also adds a simple VO to wrap the webhook(s) response.
Drops unsupported PHP versions.

I'll add an upstream PR as well; but looking at the repo activity, I don't expect these changes to be merged anytime soon.